### PR TITLE
fix: Executable doesn't crash on launch

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -1,4 +1,5 @@
 ﻿using ClanGenModTool.UI;
 using Silk.NET.Windowing;
 
+System.IO.Directory.SetCurrentDirectory(System.AppDomain.CurrentDomain.BaseDirectory);
 StartWindow window = new StartWindow();


### PR DESCRIPTION
The default directory in MacOS is the user folder, so all published builds crash on MacOS because of use of a relative path. Fixes that by setting the default directory to the executable directory.
